### PR TITLE
Avoid category type for high-cardinality id3 col when creating parquet data

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,10 @@ python csv_to_parquet_data.py --csv-dir s3://coiled-datasets/h2o-benchmark/N_1e7
 
 ## Public data on S3:
 
-The following [S3 bucket](https://s3.console.aws.amazon.com/s3/buckets/coiled-datasets?region=us-east-2&prefix=h2o-benchmark/) contains the data to perform the h2o benchmark.We provide the single files for every case (num_rows=1e7, 1e8, and 1e9) as well as a folder for each case that contains `num_files=10, 100, 1000` respectively. Folders with `_parquet` contain the parquet files. 
+The following [S3 bucket](https://s3.console.aws.amazon.com/s3/buckets/coiled-datasets?region=us-east-2&prefix=h2o-benchmark/) contains the data to perform the h2o benchmark. We provide the single files for every case (num_rows=1e7, 1e8, and 1e9) as well as a folder for each case that contains `num_files=10, 100, 1000` respectively. Folders with `_parquet` contain the parquet files. 
 
 **S3 URI:** `s3://coiled-datasets/h2o-benchmark/`
+**S3 URI (id3 no categorical):** `s3://coiled-datasets/h2o-benchmark/id3_nocat/`
 
 ## Performance reports
 

--- a/scripts/csv_to_parquet_data.py
+++ b/scripts/csv_to_parquet_data.py
@@ -25,7 +25,7 @@ def get_parquet(csv_dir, output_dir):
         dtype={
             "id1": "category",
             "id2": "category",
-            "id3": "category",
+            "id3": "string[python]",
             "id4": "Int32",
             "id5": "Int32",
             "id6": "Int32",

--- a/tests/test_create_groupby_data.py
+++ b/tests/test_create_groupby_data.py
@@ -69,7 +69,7 @@ def test_simple_parquet(tmp_path):
         dtype={
             "id1": "category",
             "id2": "category",
-            "id3": "category",
+            "id3": "string[python]",
             "id4": "Int32",
             "id5": "Int32",
             "id6": "Int32",


### PR DESCRIPTION
- [x] Closes #11